### PR TITLE
feat: use systemd timer function on systemd enabled devices

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/thin-edge/tedge-demo-main-systemd:20231105.1
+FROM ghcr.io/thin-edge/tedge-demo-main-systemd:20231115.1
 
 COPY dist/tedge-inventory*.deb /tmp/
 RUN dpkg -i /tmp/*.deb

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -28,7 +28,7 @@ contents:
       mode: 0755
 
   # service definitions
-  - src: ./src/services/systemd/tedge-inventory.service
+  - src: ./src/services/systemd/tedge-inventory.*
     dst: /lib/systemd/system/
     file_info:
       mode: 0644
@@ -40,7 +40,7 @@ contents:
       mode: 0755
     packager: deb
 
-  - src: ./src/services/systemd/tedge-inventory.service
+  - src: ./src/services/systemd/tedge-inventory.*
     dst: /lib/systemd/system/
     file_info:
       mode: 0644

--- a/src/packaging/postinstall
+++ b/src/packaging/postinstall
@@ -13,6 +13,7 @@ cleanup() {
     # This is where you remove files that were not needed on this platform / system
     if [ "${use_systemctl}" = "False" ]; then
         rm -f /lib/systemd/system/tedge-inventory.service
+        rm -f /lib/systemd/system/tedge-inventory.timer
     else
         rm -f /etc/chkconfig/tedge-inventory
         rm -f /etc/init.d/tedge-inventory
@@ -38,12 +39,11 @@ cleanInstall() {
         printf "\033[32m Reload the service unit from disk\033[0m\n"
         systemctl daemon-reload ||:
         printf "\033[32m Unmask the service\033[0m\n"
-        systemctl unmask tedge-inventory ||:
+        systemctl unmask tedge-inventory.timer ||:
         printf "\033[32m Set the preset flag for the service unit\033[0m\n"
-        systemctl preset tedge-inventory ||:
+        systemctl preset tedge-inventory.timer ||:
         printf "\033[32m Set the enabled flag for the service unit\033[0m\n"
-        systemctl enable tedge-inventory ||:
-        systemctl restart tedge-inventory ||:
+        systemctl enable tedge-inventory.timer ||:
     fi
 }
 

--- a/src/packaging/postremove
+++ b/src/packaging/postremove
@@ -22,7 +22,7 @@ do_systemd() {
     # tedge-inventory
     systemctl disable tedge-inventory ||:
     if [ -d /run/systemd/system ]; then
-        systemctl stop tedge-inventory ||:
+        systemctl stop tedge-inventory.timer ||:
     fi
 }
 

--- a/src/services/systemd/tedge-inventory.service
+++ b/src/services/systemd/tedge-inventory.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=thin-edge.io community inventory script runner
 After=network.target
-After=mosquitto.service
 
 [Service]
 Type=simple

--- a/src/services/systemd/tedge-inventory.timer
+++ b/src/services/systemd/tedge-inventory.timer
@@ -2,7 +2,7 @@
 Description=thin-edge.io community inventory script runner
 
 [Timer]
-OnBootSec=1min
+OnBootSec=30s
 OnUnitActiveSec=1h
 
 [Install]

--- a/src/services/systemd/tedge-inventory.timer
+++ b/src/services/systemd/tedge-inventory.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=thin-edge.io community inventory script runner
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=1h
+
+[Install]
+WantedBy=timers.target

--- a/tests/main/telemetry.robot
+++ b/tests/main/telemetry.robot
@@ -8,7 +8,7 @@ Suite Setup    Custom Setup
 *** Test Cases ***
 
 Inventory Script: OS information
-    ${mo}=    Cumulocity.Device Should Have Fragments    device_OS
+    ${mo}=    Cumulocity.Device Should Have Fragments    device_OS    timeout=90
     Log    ${mo["device_OS"]}
     Should Not Be Empty    ${mo["device_OS"]["arch"]}
     Should Not Be Empty    ${mo["device_OS"]["displayName"]}
@@ -18,7 +18,7 @@ Inventory Script: OS information
     Should Not Be Empty    ${mo["device_OS"]["version"]}
 
 Inventory Script: Hardware information
-    ${mo}=    Cumulocity.Device Should Have Fragments    c8y_Hardware
+    ${mo}=    Cumulocity.Device Should Have Fragments    c8y_Hardware    timeout=90
     Log    ${mo["c8y_Hardware"]}
     Should Not Be Empty    ${mo["c8y_Hardware"]["model"]}
     Should Not Be Empty    ${mo["c8y_Hardware"]["serialNumber"]}


### PR DESCRIPTION
Use systemd-timer to run the inventory scripts periodically.

* Start 30s after boot
* Run periodically (every hour after the boot time)