### PR TITLE
ci: don't trigger test on main as merge group is used

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,8 +9,6 @@ on:
   # Reference: https://dev.to/petrsvihlik/using-environment-protection-rules-to-secure-secrets-when-building-external-forks-with-pullrequesttarget-hci
   pull_request_target:
     branches: [ main ]
-  push:
-    branches: [ main ]
   merge_group:
 jobs:
   test:


### PR DESCRIPTION
Running the tests after the merge queue/group doesn't make sense and is just a waste of resources.