### PR TITLE
use system clock sync status as cache invalidator

### DIFF
--- a/src/scripts.d/50_c8y_Hardware
+++ b/src/scripts.d/50_c8y_Hardware
@@ -39,6 +39,14 @@ hardware_info_device() {
     echo "serialNumber=\"$SERIAL\""
 }
 
+# FIXME: Workaround for an issue when publishing a message before the system clock has been synchronized
+# results in the message not being sent to the cloud
+# By adding the sysClockSync value, it will bypass the tedge-mapper-c8y diff check
+if command -V timedatectl >/dev/null 2>&1; then
+    system_time_insync=$(timedatectl | grep "System clock synchronized" | cut -d: -f2 | xargs)
+    echo "sysClockSync=\"$system_time_insync\""
+fi
+
 # Check if running in a container or not (note, this is just a rough check)
 if [ -f /.dockerenv ] || [ -f /run/.containerenv ]; then
     hardware_info_container

--- a/src/scripts.d/60_device_OS
+++ b/src/scripts.d/60_device_OS
@@ -50,4 +50,12 @@ if command -V uname >/dev/null >&1; then
     printf 'kernel="%s"\n' "$(uname -v)"
 fi
 
+# FIXME: Workaround for an issue when publishing a message before the system clock has been synchronized
+# results in the message not being sent to the cloud
+# By adding the sysClockSync value, it will bypass the tedge-mapper-c8y diff check
+if command -V timedatectl >/dev/null 2>&1; then
+    system_time_insync=$(timedatectl | grep "System clock synchronized" | cut -d: -f2 | xargs)
+    echo "sysClockSync=\"$system_time_insync\""
+fi
+
 exit "$EXIT_OK"


### PR DESCRIPTION
Avoid an issue where publishing inventory data to the mapper before the system clock has been synchronized results in the data not being pushed to the cloud