### PR TITLE
fix(packaging): change tedge to recommended dependency

### DIFF
--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -12,7 +12,9 @@ vendor: thin-edge.io
 homepage: https://github.com/thin-edge/tedge-inventory-plugin
 license: Apache License 2.0
 disable_globbing: false
-depends:
+# Use weak dependency so it can be installed in alpine environments
+# which use the base tedge container image (where the package is not installed, only the binaries are present)
+recommends:
   - tedge
 apk:
   # Use noarch instead of "all"


### PR DESCRIPTION
Don't enforce installing tedge so that the apk (alpine) package can be installed into the tedge container image (which does not have the "tedge" apk package installed, it only has the binaries)