### PR TITLE
feat: fallback to mac address of first adapter for the serial number

### DIFF
--- a/src/scripts.d/50_c8y_Hardware
+++ b/src/scripts.d/50_c8y_Hardware
@@ -68,6 +68,45 @@ hardware_info_container() {
     echo "serialNumber=\"$SERIAL\""
 }
 
+get_mac_address() {
+    SCN=/sys/class/net
+    min=65535
+    arphrd_ether=1
+    ifdev=
+
+    # find iface with lowest ifindex, skip non ARPHRD_ETHER types (lo, sit ...)
+    for dev in "$SCN"/*; do
+        if [ ! -f "$dev/type" ]; then
+            continue
+        fi
+
+        iftype=$(cat "$dev/type")
+        if [ "$iftype" -ne $arphrd_ether ]; then
+            continue
+        fi
+
+        # Skip dummy interfaces
+        if echo "$dev" | grep -q "$SCN/dummy" 2>/dev/null; then
+            continue
+        fi
+
+        idx=$(cat "$dev/ifindex")
+        if [ "$idx" -lt "$min" ]; then
+            min=$idx
+            ifdev=$dev
+        fi
+    done
+
+    if [ -z "$ifdev" ]; then
+        echo "no suitable interfaces found" >&2
+        exit 1
+    else
+        echo "using interface $ifdev" >&2
+        # grab MAC address
+        cat "$ifdev/address"
+    fi
+}
+
 hardware_info_device() {
     MODEL=$(grep Model /proc/cpuinfo | cut -d: -f2- | xargs)
     HARDWARE=$(grep "^Hardware" /proc/cpuinfo | cut -d: -f2- | xargs)
@@ -79,6 +118,12 @@ hardware_info_device() {
             # Example product: Sipeed Lichee RV Dock, licheerv
             MODEL=$(lshw -C system 2>/dev/null | grep product | cut -d: -f2- | xargs)
         fi
+    fi
+
+    if [ -z "$SERIAL" ]; then
+        # TODO: not all cpus have a serial number /proc/cpuinfo
+        # Fallback to using the mac address
+        SERIAL="$(get_mac_address 2>/dev/null)"
     fi
 
     echo "model=\"$MODEL\""


### PR DESCRIPTION
Use the mac address of the first adapter if the serial number is not present in the `/proc/cpuinfo` file.