### PR TITLE
fix(hardware): normalize revision value to prevent leading '-' values

### DIFF
--- a/src/scripts.d/50_c8y_Hardware
+++ b/src/scripts.d/50_c8y_Hardware
@@ -126,8 +126,12 @@ hardware_info_device() {
         SERIAL="$(get_mac_address 2>/dev/null)"
     fi
 
+    # Join hardware and revision by "-" but any one of them can be empty (so prevent output like "-abcdef")
+    # by using xargs to trim leading/trailing space, and then replacing any spaces with '-' using tr
+    NORMALIZED_REVISION=$(echo "${HARDWARE} ${REVISION}" | xargs | tr ' ' '-')
+
     echo "model=\"$MODEL\""
-    echo "revision=\"$HARDWARE-$REVISION\""
+    echo "revision=\"$NORMALIZED_REVISION\""
     echo "serialNumber=\"$SERIAL\""
 }
 

--- a/tests/main/telemetry.robot
+++ b/tests/main/telemetry.robot
@@ -22,6 +22,7 @@ Inventory Script: Hardware information
     Log    ${mo["c8y_Hardware"]}
     Should Not Be Empty    ${mo["c8y_Hardware"]["model"]}
     Should Not Be Empty    ${mo["c8y_Hardware"]["serialNumber"]}
+    Should Not Start With    ${mo["c8y_Hardware"]["serialNumber"]}    -
     Should Not Be Empty    ${mo["c8y_Hardware"]["revision"]}
 
 Inventory Script: Position information


### PR DESCRIPTION
Normalize the `c8y_Hardware.revision` value by avoid cases where the output can have a leading `-` (dash).

This was notable on Raspberry Pi devices:

**Before**

```
revision="-d04170"
```

**After**

```
revision="d04170"
```