### PR TITLE
feat: add certificate meta information on device_Certificate

### DIFF
--- a/src/scripts.d/20_device_Certificate
+++ b/src/scripts.d/20_device_Certificate
@@ -15,16 +15,21 @@ if [ -z "$CURRENT_CERT_INFO" ]; then
     exit "$EXIT_NOT_SUPPORTED"
 fi
 
-SUBJECT=$(echo "$CURRENT_CERT_INFO" | grep -i "^Subject" | sed 's/Subject *: *//g')
-ISSUER=$(echo "$CURRENT_CERT_INFO" | grep -i "^Issuer" | sed 's/Issuer *: *//g')
-THUMBPRINT=$(echo "$CURRENT_CERT_INFO" | grep -i "^Thumbprint" | sed 's/Thumbprint *: *//g' | tr '[:upper:]' '[:lower:]')
+get_cert_property() {
+    PATTERN="$1"
+    echo "$CURRENT_CERT_INFO" | grep -i "$PATTERN" | cut -d: -f2- | xargs
+}
+
+SUBJECT=$(get_cert_property "^Subject")
+ISSUER=$(get_cert_property "^Issuer")
+THUMBPRINT=$(get_cert_property "^Thumbprint" | tr '[:upper:]' '[:lower:]')
 SELF_SIGNED="false"
 if [ "$SUBJECT" = "$ISSUER" ]; then
     SELF_SIGNED="true"    
 fi
 
-VALID_FROM=$(echo "$CURRENT_CERT_INFO" | grep -i "^Valid from" | sed 's/Valid from *: *//g')
-VALID_UNTIL=$(echo "$CURRENT_CERT_INFO" | grep -i "^Valid until" | sed 's/Valid until *: *//g')
+VALID_FROM=$(get_cert_property "^Valid from")
+VALID_UNTIL=$(get_cert_property "^Valid until\|^Valid up to")
 
 printf 'subject="%s"\n' "$SUBJECT"
 printf 'issuer="%s"\n' "$ISSUER"

--- a/src/scripts.d/20_device_Certificate
+++ b/src/scripts.d/20_device_Certificate
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+EXIT_OK=0
+#EXIT_NOT_SUPPORTED=2
+
+#
+# Device certificate information
+#
+
+CURRENT_CERT_INFO=$(tedge cert show ||:)
+
+SUBJECT=$(echo "$CURRENT_CERT_INFO" | grep -i "^Subject" | sed 's/Subject *: *//g')
+ISSUER=$(echo "$CURRENT_CERT_INFO" | grep -i "^Issuer" | sed 's/Issuer *: *//g')
+THUMBPRINT=$(echo "$CURRENT_CERT_INFO" | grep -i "^Thumbprint" | sed 's/Thumbprint *: *//g' | tr '[:upper:]' '[:lower:]')
+SELF_SIGNED="false"
+if [ "$SUBJECT" = "$ISSUER" ]; then
+    SELF_SIGNED="true"    
+fi
+
+VALID_FROM=$(echo "$CURRENT_CERT_INFO" | grep -i "^Valid from" | sed 's/Valid from *: *//g')
+VALID_UNTIL=$(echo "$CURRENT_CERT_INFO" | grep -i "^Valid until" | sed 's/Valid until *: *//g')
+
+printf 'subject="%s"\n' "$SUBJECT"
+printf 'issuer="%s"\n' "$ISSUER"
+printf 'thumbprint="%s"\n' "$THUMBPRINT"
+printf 'selfSigned="%s"\n' "$SELF_SIGNED"
+printf 'validFrom="%s"\n' "$VALID_FROM"
+printf 'validUntil="%s"\n' "$VALID_UNTIL"
+
+exit "$EXIT_OK"

--- a/src/scripts.d/20_device_Certificate
+++ b/src/scripts.d/20_device_Certificate
@@ -2,13 +2,18 @@
 set -e
 
 EXIT_OK=0
-#EXIT_NOT_SUPPORTED=2
+EXIT_NOT_SUPPORTED=2
 
 #
 # Device certificate information
 #
 
 CURRENT_CERT_INFO=$(tedge cert show ||:)
+
+if [ -z "$CURRENT_CERT_INFO" ]; then
+    echo "Could not read device certificate information from 'tedge cert show'" >&2
+    exit "$EXIT_NOT_SUPPORTED"
+fi
 
 SUBJECT=$(echo "$CURRENT_CERT_INFO" | grep -i "^Subject" | sed 's/Subject *: *//g')
 ISSUER=$(echo "$CURRENT_CERT_INFO" | grep -i "^Issuer" | sed 's/Issuer *: *//g')

--- a/tests/main/telemetry.robot
+++ b/tests/main/telemetry.robot
@@ -36,6 +36,16 @@ Inventory Script: Position information
     Should Be True    ${mo["c8y_Position"]["lat"]} != 0
     Should Be True    ${mo["c8y_Position"]["lng"]} != 0
 
+Inventory Script: Device Certificate information
+    ${mo}=    Cumulocity.Device Should Have Fragments    device_Certificate    timeout=90
+    Log    ${mo["device_Certificate"]}
+    Should Not Be Empty    ${mo["device_Certificate"]["issuer"]}
+    Should Not Be Empty    ${mo["device_Certificate"]["subject"]}
+    Should Not Be Empty    ${mo["device_Certificate"]["thumbprint"]}
+    Should Not Be Empty    ${mo["device_Certificate"]["selfSigned"]}
+    Should Not Be Empty    ${mo["device_Certificate"]["validFrom"]}
+    Should Not Be Empty    ${mo["device_Certificate"]["validUntil"]}
+
 *** Keywords ***
 
 Custom Setup


### PR DESCRIPTION
Add inventory script to publish the certificate meta information of the current certificate.

**Example**

The following properties will be added to the `device_Certificate` digital twin property.

```sh
subject="CN=rmi_helloworld001, O=Thin Edge, OU=Device"
issuer="CN=rmi_helloworld001, O=Thin Edge, OU=Device"
thumbprint="d83ff7007cda82e53672f9b0e75176791cef8eb9"
selfSigned="true"
validFrom="Wed, 02 Apr 2025 07:12:51 +0000"
validUntil="Thu, 02 Apr 2026 07:12:51 +0000"
```