### PR TITLE
feat: split the inventory scripts into different packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ The following linux package formats are provided on the releases page and also i
 |Alpine Linux (apk)|[![Latest version of 'tedge-inventory-plugin' @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/thinedge/community/alpine/tedge-inventory-plugin/latest/a=noarch;d=alpine%252Fany-version/?render=true&show_latest=true)](https://cloudsmith.io/~thinedge/repos/community/packages/detail/alpine/tedge-inventory-plugin/latest/a=noarch;d=alpine%252Fany-version/)|
 |RHEL/CentOS/Fedora (rpm)|[![Latest version of 'tedge-inventory-plugin' @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/thinedge/community/rpm/tedge-inventory-plugin/latest/a=noarch;d=any-distro%252Fany-version;t=binary/?render=true&show_latest=true)](https://cloudsmith.io/~thinedge/repos/community/packages/detail/rpm/tedge-inventory-plugin/latest/a=noarch;d=any-distro%252Fany-version;t=binary/)|
 
+
+If you don't wish to install all of the plugins then you can also selectively install the packages 
+
+* tedge-inventory-core
+* tedge-inventory-c8y-hardware
+* tedge-inventory-c8y-position
+* tedge-inventory-device-certificate
+* tedge-inventory-device-os
+
+For example, on Debian, after you have configured the Community repository, you install just the plugins
+
+```sh
+apt-get update
+apt-get install \
+    tedge-inventory-device-certificate \
+    tedge-inventory-device-os
+```
+
 ### What will be deployed to the device?
 
 * The following service will be installed

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -27,7 +27,17 @@ packages=(
 
 for package_type in "${packages[@]}"; do
     echo ""
-    nfpm package --packager "$package_type" --target ./dist/
+    # meta package
+    nfpm package --packager "$package_type" --target ./dist/ -f nfpm.yaml
+
+    # core
+    nfpm package --packager "$package_type" --target ./dist/ -f nfpm.core.yaml
+
+    # plugins
+    nfpm package --packager "$package_type" --target ./dist/ -f nfpm.c8y-hardware.yaml
+    nfpm package --packager "$package_type" --target ./dist/ -f nfpm.c8y-position.yaml
+    nfpm package --packager "$package_type" --target ./dist/ -f nfpm.device-certificate.yaml
+    nfpm package --packager "$package_type" --target ./dist/ -f nfpm.device-os.yaml
 done
 
 echo "Created all linux packages"

--- a/nfpm.c8y-hardware.yaml
+++ b/nfpm.c8y-hardware.yaml
@@ -1,28 +1,23 @@
 # yaml-language-server: $schema=https://nfpm.goreleaser.com/static/schema.json
 ---
-name: tedge-inventory-plugin
+name: tedge-inventory-c8y-hardware
 arch: all
 platform: linux
 version: ${SEMVER}
 section: misc
 priority: optional
 maintainer: Community <community@thin-edge.io>
-description: thin-edge.io inventory scripts
+description: thin-edge.io inventory scripts for c8y_Hardware
 vendor: thin-edge.io
 homepage: https://github.com/thin-edge/tedge-inventory-plugin
 license: Apache License 2.0
 disable_globbing: false
-
 depends:
   - tedge-inventory-core
-  - tedge-inventory-c8y-hardware
-  - tedge-inventory-c8y-position
-  - tedge-inventory-device-certificate
-  - tedge-inventory-device-os
-
 apk:
-  # Use noarch instead of "all"
   arch: noarch
-deb:
-  fields:
-    Multi-Arch: allowed
+contents:
+  - src: ./src/scripts.d/50_c8y_Hardware
+    dst: /usr/share/tedge-inventory/scripts.d/
+    file_info:
+      mode: 0755

--- a/nfpm.c8y-position.yaml
+++ b/nfpm.c8y-position.yaml
@@ -1,28 +1,23 @@
 # yaml-language-server: $schema=https://nfpm.goreleaser.com/static/schema.json
 ---
-name: tedge-inventory-plugin
+name: tedge-inventory-c8y-position
 arch: all
 platform: linux
 version: ${SEMVER}
 section: misc
 priority: optional
 maintainer: Community <community@thin-edge.io>
-description: thin-edge.io inventory scripts
+description: thin-edge.io inventory scripts for c8y_Position
 vendor: thin-edge.io
 homepage: https://github.com/thin-edge/tedge-inventory-plugin
 license: Apache License 2.0
 disable_globbing: false
-
 depends:
   - tedge-inventory-core
-  - tedge-inventory-c8y-hardware
-  - tedge-inventory-c8y-position
-  - tedge-inventory-device-certificate
-  - tedge-inventory-device-os
-
 apk:
-  # Use noarch instead of "all"
   arch: noarch
-deb:
-  fields:
-    Multi-Arch: allowed
+contents:
+  - src: ./src/scripts.d/80_c8y_Position
+    dst: /usr/share/tedge-inventory/scripts.d/
+    file_info:
+      mode: 0755

--- a/nfpm.core.yaml
+++ b/nfpm.core.yaml
@@ -1,0 +1,77 @@
+# yaml-language-server: $schema=https://nfpm.goreleaser.com/static/schema.json
+---
+name: tedge-inventory-core
+arch: all
+platform: linux
+version: ${SEMVER}
+section: misc
+priority: optional
+maintainer: Community <community@thin-edge.io>
+description: thin-edge.io inventory script runner for executing inventory scripts
+vendor: thin-edge.io
+homepage: https://github.com/thin-edge/tedge-inventory-plugin
+license: Apache License 2.0
+disable_globbing: false
+
+provides:
+  - tedge-inventory
+
+apk:
+  # Use noarch instead of "all"
+  arch: noarch
+contents:
+  - src: ./src/runner.sh
+    dst: /usr/share/tedge-inventory/runner.sh
+    file_info:
+      mode: 0755
+
+  - src: ./src/scripts.d/README
+    dst: /usr/share/tedge-inventory/scripts.d/
+    file_info:
+      mode: 0755
+
+  # service definitions
+  - src: ./src/services/systemd/*
+    dst: /lib/systemd/system/
+    file_info:
+      mode: 0644
+    packager: deb
+
+  - src: ./src/services/sysvinit/tedge-inventory
+    dst: /etc/init.d/
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ./src/services/systemd/*
+    dst: /lib/systemd/system/
+    file_info:
+      mode: 0644
+    packager: rpm
+  
+  - src: ./src/services/sysvinit/tedge-inventory
+    dst: /etc/init.d/
+    file_info:
+      mode: 0755
+    packager: rpm
+
+overrides:
+  apk:
+    # Note: don't depend on tedge for apk to allow installing in the tedge container image (which just has the tedge binaries)
+    scripts:
+      postinstall: src/packaging/postinstall
+      postremove: src/packaging/postremove
+
+  rpm:
+    recommends:
+      - tedge
+    scripts:
+      postinstall: src/packaging/postinstall
+      postremove: src/packaging/postremove
+
+  deb:
+    recommends:
+      - tedge
+    scripts:
+      postinstall: src/packaging/postinstall
+      postremove: src/packaging/postremove

--- a/nfpm.device-certificate.yaml
+++ b/nfpm.device-certificate.yaml
@@ -1,28 +1,23 @@
 # yaml-language-server: $schema=https://nfpm.goreleaser.com/static/schema.json
 ---
-name: tedge-inventory-plugin
+name: tedge-inventory-device-certificate
 arch: all
 platform: linux
 version: ${SEMVER}
 section: misc
 priority: optional
 maintainer: Community <community@thin-edge.io>
-description: thin-edge.io inventory scripts
+description: thin-edge.io inventory scripts for device_Certificate
 vendor: thin-edge.io
 homepage: https://github.com/thin-edge/tedge-inventory-plugin
 license: Apache License 2.0
 disable_globbing: false
-
 depends:
   - tedge-inventory-core
-  - tedge-inventory-c8y-hardware
-  - tedge-inventory-c8y-position
-  - tedge-inventory-device-certificate
-  - tedge-inventory-device-os
-
 apk:
-  # Use noarch instead of "all"
   arch: noarch
-deb:
-  fields:
-    Multi-Arch: allowed
+contents:
+  - src: ./src/scripts.d/20_device_Certificate
+    dst: /usr/share/tedge-inventory/scripts.d/
+    file_info:
+      mode: 0755

--- a/nfpm.device-os.yaml
+++ b/nfpm.device-os.yaml
@@ -1,28 +1,23 @@
 # yaml-language-server: $schema=https://nfpm.goreleaser.com/static/schema.json
 ---
-name: tedge-inventory-plugin
+name: tedge-inventory-device-os
 arch: all
 platform: linux
 version: ${SEMVER}
 section: misc
 priority: optional
 maintainer: Community <community@thin-edge.io>
-description: thin-edge.io inventory scripts
+description: thin-edge.io inventory scripts for device OS
 vendor: thin-edge.io
 homepage: https://github.com/thin-edge/tedge-inventory-plugin
 license: Apache License 2.0
 disable_globbing: false
-
 depends:
   - tedge-inventory-core
-  - tedge-inventory-c8y-hardware
-  - tedge-inventory-c8y-position
-  - tedge-inventory-device-certificate
-  - tedge-inventory-device-os
-
 apk:
-  # Use noarch instead of "all"
   arch: noarch
-deb:
-  fields:
-    Multi-Arch: allowed
+contents:
+  - src: ./src/scripts.d/60_device_OS
+    dst: /usr/share/tedge-inventory/scripts.d/
+    file_info:
+      mode: 0755

--- a/src/scripts.d/README
+++ b/src/scripts.d/README
@@ -1,0 +1,6 @@
+Place inventory scripts in this folder where the script match the following criteria:
+
+* script name must match "[0-9][0-9]_*"
+* script must be executable
+* script must be owned by root
+* chmod must be "0755"


### PR DESCRIPTION
Allow users to selectively install different inventory packages.

If you want to install all of the plugins then you can install:

* tedge-inventory-plugin

Or if you only want to install specific plugins, then you can select ones:

* tedge-inventory-core
* tedge-inventory-c8y-hardware
* tedge-inventory-c8y-position
* tedge-inventory-device-certificate
* tedge-inventory-device-os