### PR TITLE
feat: add device_Network inventory script

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -39,6 +39,7 @@ for package_type in "${packages[@]}"; do
     nfpm package --packager "$package_type" --target ./dist/ -f nfpm.device-certificate.yaml
     nfpm package --packager "$package_type" --target ./dist/ -f nfpm.device-os.yaml
     nfpm package --packager "$package_type" --target ./dist/ -f nfpm.device-resources.yaml
+    nfpm package --packager "$package_type" --target ./dist/ -f nfpm.device-network.yaml
 done
 
 echo "Created all linux packages"

--- a/nfpm.device-network.yaml
+++ b/nfpm.device-network.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://nfpm.goreleaser.com/static/schema.json
+---
+name: tedge-inventory-device-network
+arch: all
+platform: linux
+version: ${SEMVER}
+section: misc
+priority: optional
+maintainer: Community <community@thin-edge.io>
+description: thin-edge.io inventory scripts for device_Network
+vendor: thin-edge.io
+homepage: https://github.com/thin-edge/tedge-inventory-plugin
+license: Apache License 2.0
+disable_globbing: false
+depends:
+  - tedge-inventory-core
+apk:
+  arch: noarch
+contents:
+  - src: ./src/scripts.d/66_device_Network
+    dst: /usr/share/tedge-inventory/scripts.d/
+    file_info:
+      mode: 0755

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -20,6 +20,7 @@ provides:
   - tedge-inventory-device-certificate
   - tedge-inventory-device-os
   - tedge-inventory-device-resources
+  - tedge-inventory-device-network
 
 apk:
   # Use noarch instead of "all"

--- a/src/scripts.d/66_device_Network
+++ b/src/scripts.d/66_device_Network
@@ -1,0 +1,88 @@
+#!/bin/sh
+set -e
+
+# Server to be used for the ping test
+PING_TEST_SERVER=${PING_TEST_SERVER:-8.8.8.8}
+
+EXIT_OK=0
+
+# All the network interfaces
+INTERFACES=$(ls /sys/class/net)
+
+get_lan_info() {
+    for IFACE in $INTERFACES; do
+        # Exclude loopback
+        if [ "$IFACE" = "lo" ]; then
+            continue
+        fi
+
+        MAC=$(cat /sys/class/net/"$IFACE"/address)
+        STATUS=$(cat /sys/class/net/"$IFACE"/operstate)
+
+        IP4_LIST=$(ip -4 addr show dev "$IFACE" 2>/dev/null | awk '
+            $1 == "inet" {
+                ip_list = (ip_list ? ip_list "," : "") $2;
+            }
+            END {
+                print ip_list
+            }
+        ')
+
+        IP6_LIST=$(ip -6 addr show dev "$IFACE" 2>/dev/null | awk '
+            $1 == "inet6" && $2 !~ /^fe80/ {
+                ip_list = (ip_list ? ip_list "," : "") $2;
+            }
+            END {
+                print ip_list
+            }
+        ')
+
+        printf 'LAN_%s={"name":"%s","ip4":"%s","ip6":"%s","mac":"%s","status":"%s"}\n' "$IFACE" "$IFACE" "${IP4_LIST:-}" "${IP6_LIST:-}" "${MAC:-}" "${STATUS:-unknown}"
+
+    done
+}
+
+get_wan_info() {
+    COUNT=1           # PING count
+    DEADLINE=10        # PING deadline
+    PING_STATUS="not_available"
+
+    if command -v ping >/dev/null 2>&1; then
+        if ping -c "$COUNT" -w "$DEADLINE" "$PING_TEST_SERVER" > /dev/null 2>&1; then
+            PING_STATUS="ok"
+        else
+            PING_STATUS="failed"
+        fi
+    fi
+
+    if command -v curl >/dev/null 2>&1; then
+        PUBLIC_IP=$(curl -s --connect-timeout 15 ifconfig.me ||:)
+    fi
+    printf 'WAN={"publicIp":"%s","pingStatus":"%s"}\n' "${PUBLIC_IP:-unknown}" "${PING_STATUS}"
+}
+
+# Get system resolver DNS info
+get_system_dns_info() {
+    DNS_SERVERS=
+    if [ -f /etc/resolv.conf ]; then
+        DNS_SERVERS=$(awk '
+                /^nameserver / {
+                    output = (output ? output "," : "") $2
+                }
+                END {
+                    print output
+                }
+            ' /etc/resolv.conf )
+    fi
+    if [ -n "$DNS_SERVERS" ]; then
+        printf 'dns="%s"\n' "${DNS_SERVERS:-}"
+    else
+        echo "No dns servers found" >&2
+    fi
+}
+
+get_lan_info
+get_wan_info
+get_system_dns_info
+
+exit "$EXIT_OK"

--- a/tests/main/telemetry.robot
+++ b/tests/main/telemetry.robot
@@ -54,6 +54,17 @@ Inventory Script: Device Resource information
     Should Be True    ${mo["device_Resources"]["memoryMiB"]} >= 0
     Should Be True    ${mo["device_Resources"]["swapMiB"]} >= 0
 
+Inventory Script: Device Network information
+    ${mo}=    Cumulocity.Device Should Have Fragments    device_Network    timeout=90
+    Log    ${mo["device_Network"]}
+    Should Not Be Empty    ${mo["device_Network"]["LAN_eth0"]["name"]}
+    # Skip check as the CI may not have an ip4 address
+    # Should Not Be Empty    ${mo["device_Network"]["LAN_eth0"]["ip4"]}
+    Should Not Be Empty    ${mo["device_Network"]["LAN_eth0"]["mac"]}
+    Should Not Be Empty    ${mo["device_Network"]["WAN"]["publicIp"]}
+    Should Not Be Empty    ${mo["device_Network"]["WAN"]["pingStatus"]}
+    Should Not Be Empty    ${mo["device_Network"]["dns"]}
+
 *** Keywords ***
 
 Custom Setup


### PR DESCRIPTION
This script adds network related information to inventory.

Example output:
MQTT topic: `te/device/main///twin/device_Network`
```json
{
  "LAN_eth0": {
    "name": "eth0",
    "ip4": "172.21.0.2/16",
    "ip6": "",
    "mac": "02:42:ac:15:00:02",
    "status": "up"
  },
  "WAN": {
    "publicIp": "217.230.89.185",
    "pingStatus": "ok"
  },
  "dns": "127.0.0.11"
}
```

Related to #28

---

P.S. I do not know how to test DHCP server inside container... Should I make a dummy config file `/etc/dnsmasq.conf`? The example above is together with the dummy config file.